### PR TITLE
Copy dict in order to avoid destructive actions

### DIFF
--- a/odin/resources.py
+++ b/odin/resources.py
@@ -348,6 +348,8 @@ def create_resource_from_dict(d, resource=None, full_clean=True):
     :param full_clean: Do a full clean as part of the creation.
     """
     assert isinstance(d, dict)
+    
+    d = d.copy()
 
     # Get the correct resource name
     if isinstance(resource, type) and issubclass(resource, Resource):


### PR DESCRIPTION
I can make this optional (opt-out) if needed by there's no need to destruct the original dict.
