### PR TITLE
Added meta option to customise the sort order of fields.

### DIFF
--- a/docs/ref/codecs/csv_codec.rst
+++ b/docs/ref/codecs/csv_codec.rst
@@ -1,22 +1,2 @@
-#########
-CSV Codec
-#########
-
-Codec for iterating a CSV file and parsing into a Resource.
-
-Example
-=======
-
-Iterate a CSV file yielding resources::
-
-    from odin.codecs import csv_codec
-
-    with open('my_resources.csv') as f:
-        for resource in csv_codec.ResourceReader(f, MyResource):
-            print resource
-
-
-Limitations
-===========
-
-The CSV codec works on list of single resources with each row being mapped to a resource object.
+.. automodule:: odin.codecs.csv_codec
+    :members:

--- a/docs/ref/resources/instances.rst
+++ b/docs/ref/resources/instances.rst
@@ -207,47 +207,6 @@ This would produce a JSON document of::
         ]
     }
 
-Meta options
-============
-
-Give your resource metadata by using an inner ``class Meta``, like so::
-
-    class Book(odin.Resource):
-        title = odin.StringField()
-
-        class Meta:
-            name_space = "library"
-            verbose_name_plural = "Books"
-
-Resource metadata is “anything that’s not a field”, module_name and human-readable plural names (verbose_name and
-verbose_name_plural). None are required, and adding class Meta to a resource is completely optional.
-
-``name``
-    Override the name of a resource. This is the name used to represent the resource in a JSON document. The default
-    name is the name of the class used to define the resource.
-
-``name_space``
-    The name space is an optional string value that is used to group a set of common resources. Typically a namespace
-    should be in the form of dot-atoms eg: *university.library* or *org.poweredbypenguins*. The default is no namespace.
-
-``verbose_name``
-    A long version of the name for used when displaying a resource or in generated documentation. The default
-    *verbose_name* is a *name* attribute that has been converted to lower case and spaces put before each upper case
-    character eg: ``LibraryBook`` -> "*library book*"
-
-``verbose_name_plural``
-    A pluralised version of the *verbose_name*. The default is to use the verbose name and append an 's' character. In
-    the case of many words this does not work correctly so this attribute allows for the default behaviour to be
-    overridden.
-
-``abstract``
-    Marks the current resource as an **abstract** resource. See the section :ref:`resources-abstract` for more detail of
-    the abstract attribute. The default value for *abstract* is :const:`False`.
-
-``doc_group``
-    A grouping for documentation purposes. This is purely optional but is useful for grouping common elements together.
-    The default value for *doc_group* is :class:`None`.
-
 
 Resource inheritance
 ====================

--- a/docs/ref/resources/options.rst
+++ b/docs/ref/resources/options.rst
@@ -2,4 +2,85 @@
 Resource Meta options
 #####################
 
-*Todo* : To be written
+Meta options are flags that can be applied to a resource to affect it's behaviour or
+how it is dealt with via Odin tools.
+
+Give your resource metadata by using an inner ``class Meta``, eg::
+
+    class Book(odin.Resource):
+        class Meta:
+            name_space = "library"
+            verbose_name_plural = "Books"
+
+        title = odin.StringField()
+
+Resource metadata is “anything that’s not a field”, module_name and human-readable
+plural names (verbose_name and verbose_name_plural). None are required, and adding class
+Meta to a resource is completely optional.
+
+Meta Options
+============
+
+``name``
+    Override the name of a resource. This is the codecs when serialising/de-serialising
+    as a name to represent the resource. The default name is the name of the class used
+    to define the resource.
+
+``name_space``
+    The name space is an optional string value that is used to group a set of common
+    resources. Typically a namespace should be in the form of dot-atoms eg:
+    *university.library* or *org.poweredbypenguins*. The default is no namespace.
+
+``verbose_name``
+    A long version of the name for used when displaying a resource or in generated
+    documentation. The default *verbose_name* is a *name* attribute that has been
+    converted to lower case and spaces put before each upper case character
+    eg: ``LibraryBook`` -> "*library book*"
+
+``verbose_name_plural``
+    A pluralised version of the *verbose_name*. The default is to use the verbose name
+    and append an 's' character. In the case of many words this does not work correctly
+    so this attribute allows for the default behaviour to be overridden.
+
+``abstract``
+    Marks the current resource as an **abstract** resource. See the section
+    :ref:`resources-abstract` for more detail of the abstract attribute. The default
+    value for *abstract* is :const:`False`.
+
+``doc_group``
+    A grouping for documentation purposes. This is purely optional but is useful for
+    grouping common elements together. The default value for *doc_group* is
+    :class:`None`.
+
+``type_field``
+    The field used to identify the object type during serialisation/de-serialisation.
+    This defaults to the ``$`` character.
+
+``key_field_name``
+    Used by external libraries like ``baldr`` for identifying what field is used as
+    the key field to uniquely identify a resource instance (a good example would be
+    an ID field).
+
+``key_field_names``
+    Similar to the ``key_field_name`` but for defining multi-part keys.
+
+``field_sorting``
+    Used to customise how fields are sorted (primarily affects the order fields will
+    be exported during serialisation) during inheritance. The default behaviour is
+    to sort fields in the child resource before appending the fields from the parent
+    resource(s).
+
+    Settings this option to ``True`` will cause field sorting to happen after all of
+    the fields have been attached using the default sort method. The default method
+    sorts the fields by the order they are defined.
+
+    Supplying a callable allows for customisation of the field sorting eg sort by
+    name::
+
+        def sort_by_name(fields):
+            return sorted(fields, key=lambda f: f.name)
+
+        class MyResource(Resource):
+            class Meta:
+                field_sorting = sort_by_name
+

--- a/odin/codecs/csv_codec.py
+++ b/odin/codecs/csv_codec.py
@@ -1,8 +1,25 @@
 # -*- coding: utf-8 -*-
+"""
+CSV Codec
+~~~~~~~~~
+
+Codec for iterating a CSV file and parsing into a Resource.
+
+The CSV codec is codec that yields multiple resources rather than a single document.
+The CSV codec does not support nesting of resources.
+
+Reading data from a CSV file::
+
+    with open("my_file.csv") as f:
+        with resource in csv_codec.reader(f, MyResource):
+            ...
+
+"""
 import six
 import csv
 
 from odin import bases
+from odin.compatibility import deprecated
 from odin.datastructures import CaseLessStringList
 from odin.fields import NOT_PROVIDED
 from odin.resources import create_resource_from_iter, create_resource_from_dict
@@ -193,6 +210,7 @@ def reader(f, resource, includes_header=False, csv_module=csv, full_clean=True,
     :param ignore_header_case: Ignore the letter case on header
     :param strict_fields: Extra fields cannot be provided.
     :return: Iterable reader object
+    :rtype: Reader
 
     """
     return Reader(f, resource, full_clean,
@@ -203,6 +221,7 @@ def reader(f, resource, includes_header=False, csv_module=csv, full_clean=True,
                   **kwargs)
 
 
+@deprecated("This class will be removed in 1.1 migrate to the `reader` method.")
 class ResourceReader(csv.DictReader):
     def __init__(self, f, resource, *args, **kwargs):
         self.resource = resource

--- a/odin/resources.py
+++ b/odin/resources.py
@@ -14,7 +14,7 @@ DEFAULT_TYPE_FIELD = '$'
 class ResourceOptions(object):
     META_OPTION_NAMES = (
         'name', 'namespace', 'name_space', 'verbose_name', 'verbose_name_plural', 'abstract', 'doc_group',
-        'type_field', 'key_field_name', 'key_field_names'
+        'type_field', 'key_field_name', 'key_field_names', 'sort_parent_fields'
     )
 
     def __init__(self, meta):
@@ -33,6 +33,7 @@ class ResourceOptions(object):
         self.doc_group = None
         self.type_field = DEFAULT_TYPE_FIELD
         self.key_field_names = None
+        self.sort_parent_fields = False
 
         self._cache = {}
 
@@ -248,7 +249,8 @@ class ResourceType(type):
             new_class.add_to_class(obj_name, obj)
 
         # Sort the fields
-        new_meta.fields = sorted(new_meta.fields, key=hash)
+        if not new_meta.sort_parent_fields:
+            new_meta.fields = sorted(new_meta.fields, key=hash)
 
         # All the fields of any type declared on this model
         local_field_attnames = set([f.attname for f in new_meta.fields])
@@ -278,6 +280,10 @@ class ResourceType(type):
 
             new_meta.parents += base_meta.parents
             new_meta.parents.append(base)
+
+        # Sort the fields
+        if new_meta.sort_parent_fields:
+            new_meta.fields = sorted(new_meta.fields, key=hash)
 
         # If a key_field is defined ensure it exists
         if new_meta.key_field_names:

--- a/odin/resources.py
+++ b/odin/resources.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import copy
 import six
-from odin import bases
 
+from odin import bases
 from odin import exceptions, registration
 from odin.exceptions import ValidationError
 from odin.fields import NOT_PROVIDED
@@ -14,7 +14,7 @@ DEFAULT_TYPE_FIELD = '$'
 class ResourceOptions(object):
     META_OPTION_NAMES = (
         'name', 'namespace', 'name_space', 'verbose_name', 'verbose_name_plural', 'abstract', 'doc_group',
-        'type_field', 'key_field_name', 'key_field_names', 'sort_parent_fields'
+        'type_field', 'key_field_name', 'key_field_names', 'field_sorting'
     )
 
     def __init__(self, meta):
@@ -33,7 +33,7 @@ class ResourceOptions(object):
         self.doc_group = None
         self.type_field = DEFAULT_TYPE_FIELD
         self.key_field_names = None
-        self.sort_parent_fields = False
+        self.field_sorting = False
 
         self._cache = {}
 
@@ -249,7 +249,7 @@ class ResourceType(type):
             new_class.add_to_class(obj_name, obj)
 
         # Sort the fields
-        if not new_meta.sort_parent_fields:
+        if not new_meta.field_sorting:
             new_meta.fields = sorted(new_meta.fields, key=hash)
 
         # All the fields of any type declared on this model
@@ -282,8 +282,11 @@ class ResourceType(type):
             new_meta.parents.append(base)
 
         # Sort the fields
-        if new_meta.sort_parent_fields:
-            new_meta.fields = sorted(new_meta.fields, key=hash)
+        if new_meta.field_sorting:
+            if callable(new_meta.field_sorting):
+                new_meta.fields = new_meta.field_sorting(new_meta.fields)
+            else:
+                new_meta.fields = sorted(new_meta.fields, key=hash)
 
         # If a key_field is defined ensure it exists
         if new_meta.key_field_names:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -31,18 +31,25 @@ class ResourceA(odin.Resource):
         abstract = True
         namespace = "example"
 
+    a = odin.StringField()
+
 
 class ResourceB(ResourceA):
     class Meta:
         abstract = True
 
+    b = odin.StringField()
+
 
 class ResourceC(ResourceB):
-    pass
+    c = odin.StringField()
 
 
 class ResourceD(ResourceC):
-    pass
+    class Meta:
+        sort_parent_fields = True
+
+    d = odin.StringField()
 
 
 class TestResource(object):
@@ -143,6 +150,12 @@ class TestResource(object):
         assert [ResourceA] == ResourceB._meta.parents
         assert [ResourceA, ResourceB] == ResourceC._meta.parents
         assert [ResourceA, ResourceB, ResourceC] == ResourceD._meta.parents
+
+    def test_inherited_field_order(self):
+        assert ['c', 'b', 'a'] == [f.name for f in ResourceC._meta.fields]
+
+    def test_inherited_field_order__sort_parent_fields(self):
+        assert ['a', 'b', 'c', 'd'] == [f.name for f in ResourceD._meta.fields]
 
 
 class TestMetaOptions(object):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -47,9 +47,20 @@ class ResourceC(ResourceB):
 
 class ResourceD(ResourceC):
     class Meta:
-        sort_parent_fields = True
+        field_sorting = True
 
     d = odin.StringField()
+
+
+def sort_by_name(fields):
+    return sorted(fields, key=lambda f: f.name)
+
+
+class ResourceE(ResourceD):
+    class Meta:
+        field_sorting = sort_by_name
+
+    aa = odin.StringField()
 
 
 class TestResource(object):
@@ -151,11 +162,14 @@ class TestResource(object):
         assert [ResourceA, ResourceB] == ResourceC._meta.parents
         assert [ResourceA, ResourceB, ResourceC] == ResourceD._meta.parents
 
-    def test_inherited_field_order(self):
+    def test_field_sorting(self):
         assert ['c', 'b', 'a'] == [f.name for f in ResourceC._meta.fields]
 
-    def test_inherited_field_order__sort_parent_fields(self):
+    def test_field_sorting__enabled(self):
         assert ['a', 'b', 'c', 'd'] == [f.name for f in ResourceD._meta.fields]
+
+    def test_field_sorting__callable(self):
+        assert ['a', 'aa', 'b', 'c', 'd'] == [f.name for f in ResourceE._meta.fields]
 
 
 class TestMetaOptions(object):


### PR DESCRIPTION
The default is to append parent fields to the child resource field last after they child fields have been sorted. The new option allows for the fields to be sorted after the parent fields have been applied.