### PR TITLE
Increase coverage for csv_codec.dump(s) and fix bugs

### DIFF
--- a/odin/codecs/csv_codec.py
+++ b/odin/codecs/csv_codec.py
@@ -332,6 +332,6 @@ def dumps(resources, resource_type=None, cls=csv.writer, **kwargs):
     :param kwargs: Additional parameters to be supplied to the writer instance.
 
     """
-    buf = six.StringIO.StringIO()
-    dump(buf, resources, resource_type, cls, **kwargs)
+    buf = six.StringIO()
+    dump(buf, resources, resource_type=resource_type, cls=cls, **kwargs)
     return buf.getvalue()


### PR DESCRIPTION
Tests were missing for `csv_codec.dump()` & `csv_codec.dumps()` so I added them and fixed some bugs in `csv_codec.dumps()`.