### PR TITLE
Require pytest to be at least 3.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "pypy"
 
 install:
-  - travis_retry pip install -r requirements.txt "jinja2>=2.7" msgpack-python pyyaml pytest pytest-cov arrow
+  - travis_retry pip install -r requirements.txt "jinja2>=2.7" msgpack-python pyyaml pytest>=3.3.2 pytest-cov arrow
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then travis_retry pip install pint coveralls ply; fi
 
 script:


### PR DESCRIPTION
This will help us avoid bugs like in https://github.com/python-odin/odin/pull/44/commits/1f0a980dc218e9c00b895763b438e6d99d05b3c6