### PR TITLE
Added Python 3.7 to the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
-sudo: false
+sudo: required
+dist: xenial
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "3.7"
+  - "pypy2.7-6.0"
+  - "pypy3.5-6.0"
 
 install:
   - travis_retry pip install -r requirements.txt "jinja2>=2.7" msgpack-python pyyaml pytest>=3.3.2 pytest-cov arrow


### PR DESCRIPTION
Travis no longer supports "sudo: false".
Python 3.7 is available only on xenial.
I've also included pypy3 since it's available on those new machines.