### PR TITLE
Replace the deprecated msgpack-python package with msgpack

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,6 +1,6 @@
 jinja2>=2.7
 pint
-msgpack-python
+msgpack
 ply
 humanfriendly
 pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages =
 yaml =
     pyyaml
 msgpack =
-    msgpack-python
+    msgpack
 pint =
     pint
 arrow =


### PR DESCRIPTION
Since msgpack-python is deprecated and all new releases are done with msgpack we should use that package instead.
Note that the release notes should instruct users to remove msgpack-python first before upgrading.