### PR TITLE
Release 2.2

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,14 @@
+2.2
+===
+
+- Fix a bug where annotated resource fields failed to get resolved.
+- Fix issues where functools.cached_property does not work on annotated resources as __set_name__
+  was not being called.
+- Updates to documentation
+  - Introduce integration example for mapping Django models
+  - Flesh out mapping documentation
+  - Fix missing link to dict_codec reference.
+
 2.1
 ===
 

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -10,3 +10,4 @@ Contents
    ref/index
    integration/index
    examples/index
+   change-history

--- a/docs/integration/django/index.rst
+++ b/docs/integration/django/index.rst
@@ -1,0 +1,31 @@
+#######################
+Integration with Django
+#######################
+
+
+Mapping Django models to resources
+==================================
+
+To utilise a Django database model in a :doc:`/ref/mapping/index` a
+``FieldResolver`` is required to identify fields available on the model.
+
+The following is an example of a resolver for Django models.
+
+.. code-block:: python
+
+    from odin import registration
+    from odin.utils import getmeta
+    from odin.mapping import FieldResolverBase
+
+
+    class ModelFieldResolver(FieldResolverBase):
+        """
+        Field resolver for Django Models
+        """
+
+        def get_field_dict(self):
+            meta = getmeta(self.obj)
+            return {f.attname: f for f in meta.fields}
+
+
+    registration.register_field_resolver(ModelFieldResolver, models.Model)

--- a/docs/ref/codecs/index.rst
+++ b/docs/ref/codecs/index.rst
@@ -11,6 +11,7 @@ JSON data Odin provides the same ``load``, ``loads`` style interface.
    :maxdepth: 2
 
    csv_codec
+   dict_codec
    json_codec
    msgpack_codec
    toml_codec

--- a/docs/ref/mapping/classes.rst
+++ b/docs/ref/mapping/classes.rst
@@ -238,3 +238,20 @@ resources.
 There is also the simpler method when only a forward mapping is desired.
 
     .. autofunction:: forward_mapping_factory
+
+
+Mapping Other Types
+===================
+
+Mappers can also be used to map other to and from other object types that are not odin Resources.
+
+.. tip:: There is worked example for :doc:`Django Models </integration/django/index>` in the integration section.
+
+For mapping rules to be determined the mapper must resolve which fields/attributes
+are available on a type that can be mapped. This is done using a field resolver
+that is associated with the type (or sub type) of the object to be mapped.
+
+The field resolver is a class inherited from ``FieldResolverBase`` that can resolve
+what fields are available. This class is them registered with Odins type registry.
+
+    .. autoclass:: FieldResolverBase

--- a/docs/ref/mapping/helpers.rst
+++ b/docs/ref/mapping/helpers.rst
@@ -11,7 +11,30 @@ When defining mappings using the shorthand mappings property these methods simpl
 They also provide sensible defaults.
 
 .. automodule:: odin.mapping
+    :noindex:
 
     .. autofunction:: define
 
     .. autofunction:: assign
+
+
+Action Helpers
+==============
+
+Predefined actions for use in mapping definitions.
+
+.. automodule:: odin.mapping.helpers
+
+    .. autofunction:: sum_fields
+
+    .. autoclass:: JoinFields
+
+    .. autoclass:: SplitField
+
+    .. autoclass:: ApplyMapping
+
+
+Special Mappers
+===============
+
+    .. autoclass:: NoOpMapper

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,7 +70,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "coverage"
-version = "7.0.5"
+version = "7.1.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -348,8 +348,8 @@ lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy 
 test = ["cython", "html5lib", "pytest (>=4.6)"]
 
 [[package]]
-name = "sphinxcontrib.applehelp"
-version = "1.0.3"
+name = "sphinxcontrib-applehelp"
+version = "1.0.4"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 category = "dev"
 optional = false
@@ -449,14 +449,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "3.12.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
@@ -587,57 +587,57 @@ colorama = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 coverage = [
-    {file = "coverage-7.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2a7f23bbaeb2a87f90f607730b45564076d870f1fb07b9318d0c21f36871932b"},
-    {file = "coverage-7.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c18d47f314b950dbf24a41787ced1474e01ca816011925976d90a88b27c22b89"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef14d75d86f104f03dea66c13188487151760ef25dd6b2dbd541885185f05f40"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66e50680e888840c0995f2ad766e726ce71ca682e3c5f4eee82272c7671d38a2"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9fed35ca8c6e946e877893bbac022e8563b94404a605af1d1e6accc7eb73289"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d8d04e755934195bdc1db45ba9e040b8d20d046d04d6d77e71b3b34a8cc002d0"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7e109f1c9a3ece676597831874126555997c48f62bddbcace6ed17be3e372de8"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0a1890fca2962c4f1ad16551d660b46ea77291fba2cc21c024cd527b9d9c8809"},
-    {file = "coverage-7.0.5-cp310-cp310-win32.whl", hash = "sha256:be9fcf32c010da0ba40bf4ee01889d6c737658f4ddff160bd7eb9cac8f094b21"},
-    {file = "coverage-7.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:cbfcba14a3225b055a28b3199c3d81cd0ab37d2353ffd7f6fd64844cebab31ad"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:30b5fec1d34cc932c1bc04017b538ce16bf84e239378b8f75220478645d11fca"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1caed2367b32cc80a2b7f58a9f46658218a19c6cfe5bc234021966dc3daa01f0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d254666d29540a72d17cc0175746cfb03d5123db33e67d1020e42dae611dc196"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19245c249aa711d954623d94f23cc94c0fd65865661f20b7781210cb97c471c0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b05ed4b35bf6ee790832f68932baf1f00caa32283d66cc4d455c9e9d115aafc"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:29de916ba1099ba2aab76aca101580006adfac5646de9b7c010a0f13867cba45"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e057e74e53db78122a3979f908973e171909a58ac20df05c33998d52e6d35757"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:411d4ff9d041be08fdfc02adf62e89c735b9468f6d8f6427f8a14b6bb0a85095"},
-    {file = "coverage-7.0.5-cp311-cp311-win32.whl", hash = "sha256:52ab14b9e09ce052237dfe12d6892dd39b0401690856bcfe75d5baba4bfe2831"},
-    {file = "coverage-7.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:1f66862d3a41674ebd8d1a7b6f5387fe5ce353f8719040a986551a545d7d83ea"},
-    {file = "coverage-7.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b69522b168a6b64edf0c33ba53eac491c0a8f5cc94fa4337f9c6f4c8f2f5296c"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:436e103950d05b7d7f55e39beeb4d5be298ca3e119e0589c0227e6d0b01ee8c7"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8c56bec53d6e3154eaff6ea941226e7bd7cc0d99f9b3756c2520fc7a94e6d96"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a38362528a9115a4e276e65eeabf67dcfaf57698e17ae388599568a78dcb029"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f67472c09a0c7486e27f3275f617c964d25e35727af952869dd496b9b5b7f6a3"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:220e3fa77d14c8a507b2d951e463b57a1f7810a6443a26f9b7591ef39047b1b2"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ecb0f73954892f98611e183f50acdc9e21a4653f294dfbe079da73c6378a6f47"},
-    {file = "coverage-7.0.5-cp37-cp37m-win32.whl", hash = "sha256:d8f3e2e0a1d6777e58e834fd5a04657f66affa615dae61dd67c35d1568c38882"},
-    {file = "coverage-7.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9e662e6fc4f513b79da5d10a23edd2b87685815b337b1a30cd11307a6679148d"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:790e4433962c9f454e213b21b0fd4b42310ade9c077e8edcb5113db0818450cb"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49640bda9bda35b057b0e65b7c43ba706fa2335c9a9896652aebe0fa399e80e6"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d66187792bfe56f8c18ba986a0e4ae44856b1c645336bd2c776e3386da91e1dd"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:276f4cd0001cd83b00817c8db76730938b1ee40f4993b6a905f40a7278103b3a"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95304068686545aa368b35dfda1cdfbbdbe2f6fe43de4a2e9baa8ebd71be46e2"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:17e01dd8666c445025c29684d4aabf5a90dc6ef1ab25328aa52bedaa95b65ad7"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea76dbcad0b7b0deb265d8c36e0801abcddf6cc1395940a24e3595288b405ca0"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:50a6adc2be8edd7ee67d1abc3cd20678987c7b9d79cd265de55941e3d0d56499"},
-    {file = "coverage-7.0.5-cp38-cp38-win32.whl", hash = "sha256:e4ce984133b888cc3a46867c8b4372c7dee9cee300335e2925e197bcd45b9e16"},
-    {file = "coverage-7.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:4a950f83fd3f9bca23b77442f3a2b2ea4ac900944d8af9993743774c4fdc57af"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c2155943896ac78b9b0fd910fb381186d0c345911f5333ee46ac44c8f0e43ab"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:54f7e9705e14b2c9f6abdeb127c390f679f6dbe64ba732788d3015f7f76ef637"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ee30375b409d9a7ea0f30c50645d436b6f5dfee254edffd27e45a980ad2c7f4"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b78729038abea6a5df0d2708dce21e82073463b2d79d10884d7d591e0f385ded"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13250b1f0bd023e0c9f11838bdeb60214dd5b6aaf8e8d2f110c7e232a1bff83b"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c407b1950b2d2ffa091f4e225ca19a66a9bd81222f27c56bd12658fc5ca1209"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c76a3075e96b9c9ff00df8b5f7f560f5634dffd1658bafb79eb2682867e94f78"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f26648e1b3b03b6022b48a9b910d0ae209e2d51f50441db5dce5b530fad6d9b1"},
-    {file = "coverage-7.0.5-cp39-cp39-win32.whl", hash = "sha256:ba3027deb7abf02859aca49c865ece538aee56dcb4871b4cced23ba4d5088904"},
-    {file = "coverage-7.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:949844af60ee96a376aac1ded2a27e134b8c8d35cc006a52903fc06c24a3296f"},
-    {file = "coverage-7.0.5-pp37.pp38.pp39-none-any.whl", hash = "sha256:b9727ac4f5cf2cbf87880a63870b5b9730a8ae3a4a360241a0fdaa2f71240ff0"},
-    {file = "coverage-7.0.5.tar.gz", hash = "sha256:051afcbd6d2ac39298d62d340f94dbb6a1f31de06dfaf6fcef7b759dd3860c45"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c"},
+    {file = "coverage-7.1.0-cp310-cp310-win32.whl", hash = "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352"},
+    {file = "coverage-7.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e"},
+    {file = "coverage-7.1.0-cp311-cp311-win32.whl", hash = "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7"},
+    {file = "coverage-7.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c"},
+    {file = "coverage-7.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3"},
+    {file = "coverage-7.1.0-cp37-cp37m-win32.whl", hash = "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73"},
+    {file = "coverage-7.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0"},
+    {file = "coverage-7.1.0-cp38-cp38-win32.whl", hash = "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab"},
+    {file = "coverage-7.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c"},
+    {file = "coverage-7.1.0-cp39-cp39-win32.whl", hash = "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4"},
+    {file = "coverage-7.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3"},
+    {file = "coverage-7.1.0-pp37.pp38.pp39-none-any.whl", hash = "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda"},
+    {file = "coverage-7.1.0.tar.gz", hash = "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265"},
 ]
 docutils = [
     {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
@@ -863,9 +863,9 @@ Sphinx = [
     {file = "Sphinx-6.1.3.tar.gz", hash = "sha256:0dac3b698538ffef41716cf97ba26c1c7788dba73ce6f150c1ff5b4720786dd2"},
     {file = "sphinx-6.1.3-py3-none-any.whl", hash = "sha256:807d1cb3d6be87eb78a381c3e70ebd8d346b9a25f3753e9947e866b2786865fc"},
 ]
-"sphinxcontrib.applehelp" = [
-    {file = "sphinxcontrib.applehelp-1.0.3-py3-none-any.whl", hash = "sha256:ba0f2a22e6eeada8da6428d0d520215ee8864253f32facf958cca81e426f661d"},
-    {file = "sphinxcontrib.applehelp-1.0.3.tar.gz", hash = "sha256:83749f09f6ac843b8cb685277dbc818a8bf2d76cc19602699094fe9a74db529e"},
+sphinxcontrib-applehelp = [
+    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
+    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
 ]
 sphinxcontrib-devhelp = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
@@ -900,6 +900,6 @@ urllib3 = [
     {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
 ]
 zipp = [
-    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
-    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+    {file = "zipp-3.12.0-py3-none-any.whl", hash = "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"},
+    {file = "zipp-3.12.0.tar.gz", hash = "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "odin"
-version = "2.1"
+version = "2.2"
 description = "Data-structure definition/validation/traversal, mapping and serialisation toolkit for Python"
 authors = ["Tim Savage <tim@savage.company>"]
 license = "BSD-3-Clause"

--- a/src/odin/annotated_resource/__init__.py
+++ b/src/odin/annotated_resource/__init__.py
@@ -42,9 +42,7 @@ def _new_meta_instance(
     meta_def: Optional[object],
     new_class: "AnnotatedResourceType",
 ) -> MOT:
-    """
-    Instantiate meta options instance and handle inheritance of required fields
-    """
+    """Instantiate meta options instance and handle inheritance of required fields."""
     base_meta = getattr(new_class, "_meta", None)
     new_meta = meta_options_type(meta_def)
     new_class.add_to_class("_meta", new_meta)
@@ -73,9 +71,7 @@ def _new_meta_instance(
 
 
 def _iterate_attrs(attrs: Dict[str, Any]) -> Iterable[Tuple[str, BaseField]]:
-    """
-    Iterate through attributes and combine with annotations
-    """
+    """Iterate through attributes and combine with annotations."""
     annotations = attrs.pop("__annotations__", None) or {}
 
     # Yield any annotations processed into field instances
@@ -92,9 +88,7 @@ def _iterate_attrs(attrs: Dict[str, Any]) -> Iterable[Tuple[str, BaseField]]:
 def _add_parent_fields_to_class(
     new_class: "AnnotatedResourceType", new_meta: ResourceOptions, parents
 ):
-    """
-    Iterate through parent attrs and yield fields
-    """
+    """Iterate through parent attrs and yield fields."""
     # All the fields of any type declared on this model
     local_field_attr_names = {f.attname for f in new_meta.fields}
     field_attr_names = set(local_field_attr_names)
@@ -207,9 +201,7 @@ class AnnotatedResourceType(type):
 class AnnotatedResource(
     ResourceBase, metaclass=AnnotatedResourceType, meta_options_type=ResourceOptions
 ):
-    """
-    New Style Resource utilising type annotations for defining fields
-    """
+    """New Style Resource utilising type annotations for defining fields."""
 
 
 AResource = AnnotatedResource

--- a/src/odin/annotated_resource/__init__.py
+++ b/src/odin/annotated_resource/__init__.py
@@ -195,6 +195,8 @@ class AnnotatedResourceType(type):
         if hasattr(value, "contribute_to_class"):
             value.contribute_to_class(cls, name)
         else:
+            if hasattr(value, "__set_name__"):
+                value.__set_name__(cls, name)
             setattr(cls, name, value)
 
 

--- a/src/odin/bases.py
+++ b/src/odin/bases.py
@@ -1,23 +1,16 @@
 import abc
-from typing import Protocol
 
 
 class ResourceIterable(abc.ABC):
-    """
-    Iterable object that yields resources.
-    """
+    """Iterable object that yields resources."""
 
     @abc.abstractmethod
     def __iter__(self):
-        """
-        Iterate resources
-        """
+        """Iterate resources"""
 
 
 class TypedResourceIterable(ResourceIterable, abc.ABC):
-    """
-    Iterable object that yields a specific resource.
-    """
+    """Iterable object that yields a specific resource."""
 
     def __init__(self, resource_type):
         self.resource_type = resource_type

--- a/src/odin/mapping/__init__.py
+++ b/src/odin/mapping/__init__.py
@@ -13,7 +13,7 @@ from typing import (
 from odin import bases as base_types
 from odin import registration
 from odin.fields import NotProvided
-from odin.resources import Resource
+from odin.resources import Resource, ResourceBase
 from odin.fields.composite import ListOf, DictAs
 from odin.exceptions import MappingSetupError, MappingExecutionError
 from odin.mapping.helpers import MapListOf, MapDictAs, NoOpMapper
@@ -161,7 +161,7 @@ class ResourceFieldResolver(FieldResolverBase):
         return getmeta(self.obj).field_map
 
 
-registration.register_field_resolver(ResourceFieldResolver, Resource)
+registration.register_field_resolver(ResourceFieldResolver, ResourceBase)
 
 
 class MappingMeta(type):

--- a/src/odin/mapping/__init__.py
+++ b/src/odin/mapping/__init__.py
@@ -25,8 +25,8 @@ from odin.utils import cached_property, getmeta
 __all__ = ("Mapping", "map_field", "map_list_field", "assign_field", "define", "assign")
 
 _V = TypeVar("_V")
-Action = Callable[[Any, ...], Optional[Any]]
-BoundAction = Callable[["Mapping", Any, ...], Optional[Any]]
+Action = Callable[[Any, "..."], Optional[Any]]
+BoundAction = Callable[["Mapping", Any, "..."], Optional[Any]]
 
 
 def force_tuple(value: Union[_V, Sequence[_V]]) -> Sequence[_V]:

--- a/src/odin/mapping/helpers.py
+++ b/src/odin/mapping/helpers.py
@@ -1,25 +1,29 @@
 def sum_fields(*field_values):
-    """
-    Return a sum of fields
+    """Return the sum of a number of fields.
 
-    :param field_values:
-    :return:
+    Example::
+
+        define(from_field=("field_a", "field_b"), action=sum_fields, to_field="field_total")
 
     """
     return sum(field_values)
 
 
 class JoinFields:
-    """
-    Helper for combining multiple fields
+    """Helper for combining multiple fields.
+
+    Example::
+
+        define(from_field=("field_a", "field_b"), action=JoinFields(sep=":"), to_field="field_joined")
+
     """
 
     __slots__ = ("sep",)
 
-    def __init__(self, sep=""):
+    def __init__(self, sep: str = ""):
         self.sep = sep
 
-    def __call__(self, *field_values):
+    def __call__(self, *field_values) -> str:
         return self.sep.join(field_values)
 
 
@@ -29,8 +33,12 @@ cat_fields = CatFields = JoinFields
 
 
 class SplitField:
-    """
-    Helper for splitting a field into multiple fields.
+    """Helper for splitting a field into multiple fields.
+
+    Example::
+
+        define(from_field="field_joined", action=SplitField(sep=":"), to_field=("field_a", "field_b"))
+
     """
 
     __slots__ = (
@@ -53,13 +61,13 @@ split_field = SplitField
 
 
 class ApplyMapping:
-    """
-    Helper for applying a mapper.
+    """Helper for applying a mapper.
 
     This helper should be used along with the bind flag so the context object can be maintained.
+
     """
 
-    def __init__(self, mapping, allow_subclass=False):
+    def __init__(self, mapping, allow_subclass: bool = False):
         self.mapping = mapping
         self.allow_subclass = allow_subclass
 
@@ -74,17 +82,14 @@ class ApplyMapping:
         )
 
     def __repr__(self):
-        return "<{}: {}.{}>".format(
-            self.__class__.__name__, self.mapping.__module__, self.mapping.__name__
-        )
+        return f"<{self.__class__.__name__}: {self.mapping.__module__}.{self.mapping.__name__}>"
 
 
 MapDictAs = MapListOf = ApplyMapping
 
 
 class NoOpMapper:
-    """
-    Helper that provides the mapper interface performs no operation on the object.
+    """Helper that provides the mapper interface performs no operation on the object.
 
     This is used with the MapListOf and MapDictAs fields when both contain the same Resource type.
     """

--- a/tests/resources_annotated.py
+++ b/tests/resources_annotated.py
@@ -1,6 +1,7 @@
 import enum
 import uuid
 from datetime import datetime
+from functools import cached_property
 from typing import List, Optional
 
 import odin
@@ -11,23 +12,28 @@ class Author(odin.AResource):
     name: str
 
     class Meta:
-        namespace = None
+        namespace = "annotated"
 
 
 class Publisher(odin.AResource):
     name: str
 
     class Meta:
-        namespace = None
+        namespace = "annotated"
+
+    @cached_property
+    def capitalised_name(self):
+        return self.name.upper()
 
 
 class LibraryBook(odin.AResource, abstract=True):
     class Meta:
-        namespace = "new_library"
+        namespace = "annotated.new_library"
 
 
 class Book(LibraryBook):
     class Meta:
+        namespace = "annotated"
         key_field_name = "isbn"
 
     title: str
@@ -75,9 +81,7 @@ class IdentifiableBook(Book):
 
 
 class Subscriber(odin.Resource):
-    """
-    Mixed resource types
-    """
+    """Mixed resource types"""
 
     name: str = odin.StringField()
     address: str = odin.StringField()
@@ -93,4 +97,4 @@ class Library(odin.AnnotatedResource):
         return len(self.books)
 
     class Meta:
-        namespace = "new_library"
+        namespace = "annotated.new_library"

--- a/tests/test_annotated_resources.py
+++ b/tests/test_annotated_resources.py
@@ -42,6 +42,11 @@ class TestAnnotatedResource:
             "purchased_from",
         ]
 
+    def test_cached_properties_work_as_expected(self):
+        target = Publisher(name="Super Pub")
+
+        assert target.capitalised_name == "SUPER PUB"
+
 
 class TestAnnotatedKitchenSink:
     def test_dumps_with_valid_data(self):
@@ -63,13 +68,13 @@ class TestAnnotatedKitchenSink:
         assert json.loads(actual) == json.loads(
             """
 {
-    "$": "new_library.Library",
+    "$": "annotated.new_library.Library",
     "name": "Public Library",
     "books": [
         {
-            "$": "new_library.Book",
+            "$": "annotated.Book",
             "publisher": {
-                "$": "Publisher",
+                "$": "annotated.Publisher",
                 "name": "Macmillan"
             },
             "num_pages": 471,
@@ -77,7 +82,7 @@ class TestAnnotatedKitchenSink:
             "title": "Consider Phlebas",
             "authors": [
                 {
-                    "$": "Author",
+                    "$": "annotated.Author",
                     "name": "Iain M. Banks"
                 }
             ],

--- a/tests/test_codec_toml.py
+++ b/tests/test_codec_toml.py
@@ -78,8 +78,8 @@ class TestTomlCodec:
             rrp=19.50,
             fiction=True,
             genre="sci-fi",
-            authors=[Author(name="Iain M. Banks")],
-            publisher=Publisher(name="Macmillan"),
+            authors=[resources_annotated.Author(name="Iain M. Banks")],
+            publisher=resources_annotated.Publisher(name="Macmillan"),
             published=[datetime.datetime(1987, 1, 1)],
         )
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -12,9 +12,9 @@ class SimpleFromResource(odin.Resource):
     title = odin.StringField()
 
 
-class SimpleToResource(odin.Resource):
-    title = odin.StringField()
-    title_count = odin.StringField()
+class SimpleToResource(odin.AnnotatedResource):
+    title: str
+    title_count: str
 
 
 class FakeToResource(odin.Resource):


### PR DESCRIPTION
- Fix a bug where annotated resource fields failed to get resolved.
- Fix issues where `functools.cached_property` does not work on annotated resources as `__set_name__`
  was not being called.
- Updates to documentation
  - Introduce integration example for mapping Django models
  - Flesh out mapping documentation
  - Fix missing link to `dict_codec` reference.