### PR TITLE
Release 2.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip poetry
+        python -m pip wheel --use-pep517 "pyyaml (==6.0)"
         poetry install --all-extras --no-root
 
     - name: Test with pytest

--- a/HISTORY
+++ b/HISTORY
@@ -1,3 +1,16 @@
+2.9
+===
+
+Changes
+-------
+
+- Add support for delayed resolution of types for composite fields. This
+  allows for tree structures to be defined.
+
+  Use ``DictAs.delayed(lambda: CurrentResource)`` to define a composite field that
+  uses the current resource as the type for the dict.
+
+
 2.8.1
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "odin"
-version = "2.8.1"
+version = "2.9.0"
 description = "Data-structure definition/validation/traversal, mapping and serialisation toolkit for Python"
 authors = ["Tim Savage <tim@savage.company>"]
 license = "BSD-3-Clause"

--- a/tests/test_fields_composite.py
+++ b/tests/test_fields_composite.py
@@ -53,9 +53,23 @@ class TestFields:
 
     # DictAs ##################################################################
 
-    def test_dictas_ensure_is_resource(self):
+    def test_dictas__where_a_resource_is_not_supplied(self):
         with pytest.raises(TypeError):
             DictAs("an item")
+
+    def test_dictas__where_resource_resolution_is_delayed(self):
+        target = DictAs.delayed(lambda: ExampleResource, null=True)
+
+        assert target.of is ExampleResource
+        assert target.null is True
+
+    def test_dictas__where_resource_resolution_is_delayed_but_a_resource_is_not_supplied(
+        self,
+    ):
+        target = DictAs.delayed(lambda: "an item", null=True)
+
+        with pytest.raises(TypeError):
+            assert target.of
 
     def test_dictas_1(self):
         f = DictAs(ExampleResource)


### PR DESCRIPTION
Changes
-------

- Add support for delayed resolution of types for composite fields. This
  allows for tree structures to be defined.

  Use ``DictAs.delayed(lambda: CurrentResource)`` to define a composite field that
  uses the current resource as the type for the dict.