### PR TITLE
This fixes a bug where context is reassigned if you pass an empty con…

### DIFF
--- a/src/odin/mapping/__init__.py
+++ b/src/odin/mapping/__init__.py
@@ -515,7 +515,9 @@ class MappingBase:
             specified is returned.
 
         """
-        context = context or {}
+        if context is None:
+            context = {}
+
         mapping_result = mapping_result or cls.default_mapping_result
         context.setdefault("_loop_idx", [])
 


### PR DESCRIPTION
…text dict to .apply